### PR TITLE
security(workflows): safe-chainによるサプライチェーン保護を追加

### DIFF
--- a/.github/actions/setup-safe-chain/action.yml
+++ b/.github/actions/setup-safe-chain/action.yml
@@ -1,0 +1,9 @@
+name: Setup Aikido Safe Chain
+description: サプライチェーン保護のためAikido Safe Chainをインストール（バージョン固定）
+
+runs:
+  using: composite
+  steps:
+    - name: Install Aikido Safe Chain
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
+      shell: bash

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install Aikido Safe Chain
+        uses: ./.github/actions/setup-safe-chain
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install Aikido Safe Chain
+        uses: ./.github/actions/setup-safe-chain
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -40,11 +43,5 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
 


### PR DESCRIPTION
## Summary

- Aikido Safe Chain v1.4.7をcomposite actionとして追加（バージョンピン留め）
- claude.yml、claude-code-review.ymlの両workflowに適用
- claude.ymlの不要なボイラープレートコメントを削除

## Background

exo-brain (PR #34) での知見を反映。npm/pip等のパッケージインストール時のサプライチェーン攻撃を防止する。
バージョン管理は `.github/actions/setup-safe-chain/action.yml` の1箇所に集約。

## Test plan

- [x] claude.yml workflowが正常動作すること（@claudeメンションで確認）
- [x] claude-code-review.ymlがPR作成時に正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)