### PR TITLE
fix(ci): ドラフトPRではClaude Code Reviewをスキップする

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- ドラフト状態のPRでClaude Code Reviewワークフローが実行されないよう `if: github.event.pull_request.draft == false` 条件を追加
- 作業途中のPRで不要なレビューサイクルが走るのを防止

## Test plan
- [x] ドラフトPRを作成し、Claude Code Reviewワークフローがスキップされることを確認
- [x] ドラフトを解除（Ready for review）した際にワークフローが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)