### PR TITLE
chore: Claude Code に編集フック (biome 整形 / 機微ファイル保護) を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://json.schemastore.org/claude-code-settings.json",
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"shell": "bash",
+						"statusMessage": "機微ファイルの編集を確認中…",
+						"command": "jq -r '.tool_input.file_path // empty' | tr -d '\\r' | { read -r f; b=$(basename \"$f\"); case \"$b\" in .env|.env.*|bun.lock) jq -nc --arg b \"$b\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:($b+\" は機微ファイル/ロックファイルのため自動編集をブロックしました。手動編集が必要な場合はユーザーが直接行ってください。\")}}';; esac; }"
+					}
+				]
+			}
+		],
+		"PostToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"shell": "bash",
+						"statusMessage": "biome で整形中…",
+						"command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | tr -d '\\r' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.json|*.jsonc|*.css) bunx @biomejs/biome check --write \"$f\";; esac; } 2>/dev/null || true"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
 						"type": "command",
 						"shell": "bash",
 						"statusMessage": "biome で整形中…",
-						"command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | tr -d '\\r' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.json|*.jsonc|*.css) bunx @biomejs/biome check --write \"$f\";; esac; } 2>/dev/null || true"
+						"command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | tr -d '\\r' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.json|*.jsonc|*.css) b=node_modules/.bin/biome; [ -f \"$b\" ] || b=\"$b.exe\"; [ -f \"$b\" ] && \"$b\" check --write \"$f\";; esac; } 2>/dev/null || true"
 					}
 				]
 			}


### PR DESCRIPTION
## 概要

このテンプレートを使う開発者が、Claude Code 上でも biome 規約を自動で守れるよう、編集フック 2 件を `.claude/settings.json` として追加します。姉妹リポジトリ `EyeTech-JP/mediagroup-internship-handson` に導入したフックのうち、**汎用テンプレートに適した内容のみ**を移植したものです（MCP・Azure 固有設定は除外）。

## 変更内容

### `.claude/settings.json`（新規）— 編集フック 2 件
| フック | イベント / 対象 | 動作 |
|---|---|---|
| biome 自動整形 | `PostToolUse` / Edit・Write | 編集した `ts/tsx/js/jsx/mjs/cjs/json/jsonc/css` を `bunx @biomejs/biome check --write` で整形（他拡張子はスキップ・失敗は非ブロック）。husky の `biome check` と齟齬が出る前に整形を揃える |
| 機微ファイル保護 | `PreToolUse` / Edit・Write | `.env` / `.env.*` / `bun.lock` への自動編集を `deny` でブロック |

## テンプレート向けの調整（ハンドソン版との差分）
- **MCP 設定（`.mcp.json` / `enabledMcpjsonServers`）は入れない** … `microsoft-learn` は Azure 専用、`context7` も必須ではないため、汎用テンプレートには載せない
- **機微ファイル対象から `local.settings.json` を除外** … テンプレートに `functions/`（Azure Functions）が無いため不要
- フックコマンドは `jq` の CRLF 出力対策に `tr -d '\r'` を挟み、シェルは `bash` 固定

## 有効化
pull 後、各自の環境でフックを有効化するには `/hooks` を一度開くか Claude Code を再起動して設定を再読み込みしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
